### PR TITLE
build: check_boot_jars: Whitelist lineage touch HAL

### DIFF
--- a/core/tasks/check_boot_jars/package_whitelist.txt
+++ b/core/tasks/check_boot_jars/package_whitelist.txt
@@ -253,3 +253,7 @@ org\.codeaurora\.internal.*
 ###################################################
 # IFAA Manager used for Alipay and/or WeChat payment
 org\.ifaa\.android\.manager.*
+
+###################################################
+# Touch HAL
+vendor.lineage.touch.*


### PR DESCRIPTION
Solves the following on a dist target build:
Error: out/target/common/obj/JAVA_LIBRARIES/framework_intermediates/classes.jar contains class file vendor/lineage/touch/V1_0/ITouchscreenGesture.class, whose package name vendor.lineage.touch.V1_0 is not in the
whitelist build/make/core/tasks/check_boot_jars/package_whitelist.txt of packages allowed on the bootclasspath.

Signed-off-by: Anirudh Gupta <anirudhgupta109@gmail.com>
Change-Id: Icf45a11f88e5a610275577fb2ae35d94a92a6620
Signed-off-by: Anushek Prasal <anushekprasal@gmail.com>